### PR TITLE
Added `class="action-bar"` to <ActionBar>

### DIFF
--- a/app.component.ts
+++ b/app.component.ts
@@ -3,7 +3,7 @@ import { Component } from "@angular/core";
 @Component({
   selector: "my-app",
   template: `
-    <ActionBar title="My App"></ActionBar>
+    <ActionBar title="My App" class="action-bar"></ActionBar>
     <!-- Your UI components go here -->
   `
 })


### PR DESCRIPTION
The getting started tutorial (http://docs.nativescript.org/angular/tutorial/ng-chapter-1) contains step to change the default `core.light.css` to `sky.css` in app.css file to see the changes reflected in the app. But this is currently not happening because this CSS class is missing.